### PR TITLE
Install async-exit-stack only on python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,12 @@
-import sys
-
 from setuptools import setup
 
 install_requires = [
     "aioboto3",
     "aiohttp",
-    "async_timeout"
+    "async_timeout",
+    "async_exit_stack; python_version<'3.7'"
 ]
 
-if sys.version_info < (3, 7):
-    install_requires.append("async_exit_stack")
 
 setup(
     name="tibber_aws",


### PR DESCRIPTION
The previous set requirements based on the build machine and not the installing machine. The package needed was `async-exit-stack` which is included in the standard lib from python 3.7. Hopefully this fixes it!


In python 3.6
```sh
(tibber-pyAws) x86 mans@Manss-MBP git/tibber-pyAws (master *%) $ python -V
Python 3.6.0
(tibber-pyAws) x86 mans@Manss-MBP git/tibber-pyAws (master *%) $ pip install -e .
Obtaining file:///Users/mans/git/tibber-pyAws
...
Collecting async_exit_stack
  Using cached async_exit_stack-1.0.1-py3-none-any.whl (4.7 kB)
...
Installing collected packages: six, urllib3, typing-extensions, python-dateutil, multidict, jmespath, idna, frozenlist, yarl, idna-ssl, charset-normalizer, botocore, attrs, asynctest, async-timeout, aiosignal, wrapt, s3transfer, aioitertools, aiohttp, boto3, aiobotocore, async-exit-stack, aioboto3, tibber-aws
  Running setup.py develop for tibber-aws
Successfully installed aioboto3-9.0.0 aiobotocore-1.3.1 aiohttp-3.8.0 aioitertools-0.8.0 aiosignal-1.2.0 async-exit-stack-1.0.1 async-timeout-4.0.1 asynctest-0.13.0 attrs-21.2.0 boto3-1.17.49 botocore-1.20.49 charset-normalizer-2.0.7 frozenlist-1.2.0 idna-3.3 idna-ssl-1.1.0 jmespath-0.10.0 multidict-5.2.0 python-dateutil-2.8.2 s3transfer-0.3.7 six-1.16.0 tibber-aws-0.9.1 typing-extensions-3.10.0.2 urllib3-1.26.7 wrapt-1.13.3 yarl-1.7.2
```

And in python 3.8
```sh
-pyAws (master *%) $ python -V
Python 3.8.9
(tibber-pyAws) x86 mans@Manss-MBP git/tibber-pyAws (master *%) $ pip install -e .
Obtaining file:///Users/mans/git/tibber-pyAws
...
Installing collected packages: six, urllib3, typing-extensions, python-dateutil, multidict, jmespath, idna, frozenlist, yarl, charset-normalizer, botocore, attrs, async-timeout, aiosignal, wrapt, s3transfer, aioitertools, aiohttp, boto3, aiobotocore, aioboto3, tibber-aws
  Running setup.py develop for tibber-aws
Successfully installed aioboto3-9.2.2 aiobotocore-1.4.2 aiohttp-3.8.0 aioitertools-0.8.0 aiosignal-1.2.0 async-timeout-4.0.1 attrs-21.2.0 boto3-1.17.106 botocore-1.20.106 charset-normalizer-2.0.7 frozenlist-1.2.0 idna-3.3 jmespath-0.10.0 multidict-5.2.0 python-dateutil-2.8.2 s3transfer-0.4.2 six-1.16.0 tibber-aws-0.9.1 typing-extensions-3.10.0.2 urllib3-1.26.7 wrapt-1.13.3 yarl-1.7.2
```