### PR TITLE
fix attribute error when calling aws_base.get_aiosession()

### DIFF
--- a/tibber_aws/aws_base.py
+++ b/tibber_aws/aws_base.py
@@ -12,7 +12,11 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def get_aiosession():
-    return aiobotocore.get_session()
+    try:
+        session = aiobotocore.get_session()
+    except AttributeError:
+        session = aiobotocore.session.get_session()
+    return session
 
 
 class AwsBase:


### PR DESCRIPTION
Currently when calling S3bucket.load_data() with aiobotocore=>1.4.0 installed one gets an error and currently the lambda functions in pyML are being created with aiobotocore==2.0.0.