### PR TITLE
Add aws queue listener

### DIFF
--- a/.github/workflows/code_checker.yml
+++ b/.github/workflows/code_checker.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install depencency
         run: |
             pip install -r requirements.txt
-            pip install dlint flake8 flake8-bandit flake8-bugbear flake8-deprecated flake8-executable isort pylint
+            pip install dlint flake8 flake8-bugbear flake8-deprecated flake8-executable isort pylint
       - name: Flake8 Code Linter
         run: |
             flake8 tibber_aws/ --max-line-length=120 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Example
 gh release create 0.8.6 -t 0.8.6
 ```
 
+## Usage
+
+### SQS
+Examples:
+* [aws_queue_listener](examples/aws_queue_listener.py)
+
 ### Manually
 * Update version in setup.py
 * Create a [Release](https://github.com/tibber/tibber-pyAws/releases)

--- a/examples/aws_queue_listener.py
+++ b/examples/aws_queue_listener.py
@@ -1,8 +1,6 @@
 import asyncio
 from typing import Awaitable, Callable
 
-from aiobotocore.session import get_session
-
 from tibber_aws.aws_queue_listener import SqsListener, SqsMessage
 
 

--- a/examples/aws_queue_listener.py
+++ b/examples/aws_queue_listener.py
@@ -1,0 +1,66 @@
+import asyncio
+
+from aiobotocore.session import get_session
+
+from tibber_aws.aws_queue_listener import (AwsQueueListener, SqsMessage,
+                                           create_queue_with_subscription)
+
+
+async def handle_test_message(msg: SqsMessage):
+    print("Handling message")
+    print(msg.message)
+
+
+async def main():
+    try:
+        queue_url = await create_queue_with_subscription(
+            "test-py-aws-queue", "test-py-aws-topic"
+        )
+
+        session = get_session()
+        handlers = {"Test Message": handle_test_message}
+        async with session.create_client("sqs", "eu-west-1") as client:
+            queue_listener = AwsQueueListener(client, queue_url, handlers)
+            await queue_listener.run()
+
+    except KeyboardInterrupt:
+        pass
+
+
+asyncio.run(main())
+
+# {
+#     "Messages": [
+#         {
+#             "MessageId": "09b970fb-7af0-48a3-a1ee-f5e80f63c535",
+#             "ReceiptHandle": "AQEBuRklebnwHLXMXLaXbmzUQfY9sDm6l6uZOfA1Yfit4GlLONYbsIB7/8bgwAcSb7AuUqqLKF5Ho/WW2wtmvP7DndCMwtBzFUeIq5csZMsVGh+XhyhXECzyz2E4i5zYL+w8728gmb/NsH4oUmp5oHSukQ5w8gIzoznFEA8w5wPuRb7Lua065Ezr++pDKtQgF/Ab6AvuGuY0oPCyeJGZKZTQ4V0pPr02lhabNugJjb4AFao1kiUiGaeltUkUPayGQLr/8XX8UXCyfiWi9ScYBjiAsHMi6e8ta8hfYJ55Kx8k+gNRKwNp0FqTx0n88LthlkCgC0eVwQL2muv94Ift2MrvU9DVw73O5GmF57WxTF8y51N7A+nzD1y++hR8NggkJjGlCxHI1f+L9mKoCelL546LFw==",
+#             "MD5OfBody": "fe74d9deca8a94d36d327e217c8aa0c6",
+#             "Body": '{\n  "Type" : "Notification",\n  "MessageId" : "1f00b2a8-cfaa-58b6-852c-e83e24249122",\n  "TopicArn" : "arn:aws:sns:eu-west-1:945084044763:test-py-aws-topic",\n  "Subject" : "\\"Test Message\\"",\n  "Message" : "{\\n  \\"Data\\": \\"Hello World\\"\\n}",\n  "Timestamp" : "2022-02-28T15:25:02.462Z",\n  "SignatureVersion" : "1",\n  "Signature" : "mdimGxOWejY+PLhumoZct7Tcsv13oFrutBwTm59BvbvbaDFgHfdHLkEKr9XlGPkKo85Ub/eo4ccIgf9PBoJf0I9EQlDaGw4niiKp722D6MzY4nRoutbyazNBgobyb0Cp5hsmTBSVmiGSeU5M2IS5Jo7AXhl8oA4DXLZii2vu/LLOS9rM9YrNrdf82an7FohhLzFRki46AwJwSOKpYQn5EktB9r7KhGEs49WKzpHQ6NGFzGJVosoJCjICknkiMLpQGXm7ssnI1l06quNN0R46tP/Snq3hhNzeYMVEC2huRQNVpdS4nDPp3tpYfTNjhzGOs+q5ZcUpWDtAoxBpaYG5gA==",\n  "SigningCertURL" : "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-7ff5318490ec183fbaddaa2a969abfda.pem",\n  "UnsubscribeURL" : "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:945084044763:test-py-aws-topic:583d9061-7e8e-4def-9a93-451f0cf30e19"\n}',
+#         }
+#     ],
+#     "ResponseMetadata": {
+#         "RequestId": "9f32bc5a-9ec7-5f3e-8707-e6c3fe82ec5b",
+#         "HTTPStatusCode": 200,
+#         "HTTPHeaders": {
+#             "x-amzn-requestid": "9f32bc5a-9ec7-5f3e-8707-e6c3fe82ec5b",
+#             "date": "Wed, 02 Mar 2022 12:07:33 GMT",
+#             "content-type": "text/xml",
+#             "content-length": "2071",
+#         },
+#         "RetryAttempts": 0,
+#     },
+# }
+
+
+{
+    "Type": "Notification",
+    "MessageId": "bc97c1ac-d514-5019-a4d0-9b35b1cb24ef",
+    "TopicArn": "arn:aws:sns:eu-west-1:945084044763:test-py-aws-topic",
+    "Subject": "Test Message",
+    "Message": "Hello World",
+    "Timestamp": "2022-03-02T12:27:11.628Z",
+    "SignatureVersion": "1",
+    "Signature": "JDdZ2eyRxXl7QA7JfboWU3KqSvuVwkJf2Eyl6eAc2bbLFvSGe0Iuc2Vfa5csvlZCfagrWQ+PrmNxoWQVbfK88LLgr69xqYw1eTLL+79BCrMAbZPq7Zq2xCPwG1z78O6fWlDxoJABbVTvokWy286B3iXblG3ZYdlEJelebxjRxccaLUqdQ7Zh9tK36fpbI4sXMJam71vKCplC/mQgxBq9TAF1vfv+A89oJ+glpBWRXMhrdQshB2T66sm/M03I9TVV/6j1/A3p4mAXa89QrczAB8zTVuSx7DwM7v+uZwXXqkKedxCflRApdV0kchioXCEXe7FzRPcQRAmFrWvlQTI2Ig==",
+    "SigningCertURL": "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-7ff5318490ec183fbaddaa2a969abfda.pem",
+    "UnsubscribeURL": "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:945084044763:test-py-aws-topic:583d9061-7e8e-4def-9a93-451f0cf30e19",
+}

--- a/examples/aws_queue_listener.py
+++ b/examples/aws_queue_listener.py
@@ -1,9 +1,9 @@
 import asyncio
+from typing import Awaitable, Callable
 
 from aiobotocore.session import get_session
 
-from tibber_aws.aws_queue_listener import (AwsQueueListener, SqsMessage,
-                                           create_queue_with_subscription)
+from tibber_aws.aws_queue_listener import SqsListener, SqsMessage
 
 
 async def handle_test_message(msg: SqsMessage):
@@ -12,19 +12,12 @@ async def handle_test_message(msg: SqsMessage):
 
 
 async def main():
-    try:
-        queue_url = await create_queue_with_subscription(
-            "test-py-aws-queue", "test-py-aws-topic"
-        )
+    listener = SqsListener(
+        queue_url="test-py-aws-queue",
+        message_handler=handle_test_message,
+    )
 
-        session = get_session()
-        handlers = {"Test Message": handle_test_message}
-        async with session.create_client("sqs", "eu-west-1") as client:
-            queue_listener = AwsQueueListener(client, queue_url, handlers)
-            await queue_listener.run()
-
-    except KeyboardInterrupt:
-        pass
+    await listener.run()
 
 
 asyncio.run(main())

--- a/examples/aws_queue_listener.py
+++ b/examples/aws_queue_listener.py
@@ -11,10 +11,22 @@ async def handle_test_message(msg: SqsMessage):
     print(msg.message)
 
 
+def create_message_handler() -> Callable[[SqsMessage], Awaitable]:
+    """Create message handler."""
+
+    async def message_handler(message: SqsMessage):
+        if message.subject == "YOUR SUBJECT":
+            return await handle_test_message(message)
+        return True
+
+    return message_handler
+
+
 async def main():
+
     listener = SqsListener(
         queue_url="test-py-aws-queue",
-        message_handler=handle_test_message,
+        message_handler=create_message_handler(),
     )
 
     await listener.run()

--- a/examples/aws_queue_listener.py
+++ b/examples/aws_queue_listener.py
@@ -28,39 +28,3 @@ async def main():
 
 
 asyncio.run(main())
-
-# {
-#     "Messages": [
-#         {
-#             "MessageId": "09b970fb-7af0-48a3-a1ee-f5e80f63c535",
-#             "ReceiptHandle": "AQEBuRklebnwHLXMXLaXbmzUQfY9sDm6l6uZOfA1Yfit4GlLONYbsIB7/8bgwAcSb7AuUqqLKF5Ho/WW2wtmvP7DndCMwtBzFUeIq5csZMsVGh+XhyhXECzyz2E4i5zYL+w8728gmb/NsH4oUmp5oHSukQ5w8gIzoznFEA8w5wPuRb7Lua065Ezr++pDKtQgF/Ab6AvuGuY0oPCyeJGZKZTQ4V0pPr02lhabNugJjb4AFao1kiUiGaeltUkUPayGQLr/8XX8UXCyfiWi9ScYBjiAsHMi6e8ta8hfYJ55Kx8k+gNRKwNp0FqTx0n88LthlkCgC0eVwQL2muv94Ift2MrvU9DVw73O5GmF57WxTF8y51N7A+nzD1y++hR8NggkJjGlCxHI1f+L9mKoCelL546LFw==",
-#             "MD5OfBody": "fe74d9deca8a94d36d327e217c8aa0c6",
-#             "Body": '{\n  "Type" : "Notification",\n  "MessageId" : "1f00b2a8-cfaa-58b6-852c-e83e24249122",\n  "TopicArn" : "arn:aws:sns:eu-west-1:945084044763:test-py-aws-topic",\n  "Subject" : "\\"Test Message\\"",\n  "Message" : "{\\n  \\"Data\\": \\"Hello World\\"\\n}",\n  "Timestamp" : "2022-02-28T15:25:02.462Z",\n  "SignatureVersion" : "1",\n  "Signature" : "mdimGxOWejY+PLhumoZct7Tcsv13oFrutBwTm59BvbvbaDFgHfdHLkEKr9XlGPkKo85Ub/eo4ccIgf9PBoJf0I9EQlDaGw4niiKp722D6MzY4nRoutbyazNBgobyb0Cp5hsmTBSVmiGSeU5M2IS5Jo7AXhl8oA4DXLZii2vu/LLOS9rM9YrNrdf82an7FohhLzFRki46AwJwSOKpYQn5EktB9r7KhGEs49WKzpHQ6NGFzGJVosoJCjICknkiMLpQGXm7ssnI1l06quNN0R46tP/Snq3hhNzeYMVEC2huRQNVpdS4nDPp3tpYfTNjhzGOs+q5ZcUpWDtAoxBpaYG5gA==",\n  "SigningCertURL" : "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-7ff5318490ec183fbaddaa2a969abfda.pem",\n  "UnsubscribeURL" : "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:945084044763:test-py-aws-topic:583d9061-7e8e-4def-9a93-451f0cf30e19"\n}',
-#         }
-#     ],
-#     "ResponseMetadata": {
-#         "RequestId": "9f32bc5a-9ec7-5f3e-8707-e6c3fe82ec5b",
-#         "HTTPStatusCode": 200,
-#         "HTTPHeaders": {
-#             "x-amzn-requestid": "9f32bc5a-9ec7-5f3e-8707-e6c3fe82ec5b",
-#             "date": "Wed, 02 Mar 2022 12:07:33 GMT",
-#             "content-type": "text/xml",
-#             "content-length": "2071",
-#         },
-#         "RetryAttempts": 0,
-#     },
-# }
-
-
-{
-    "Type": "Notification",
-    "MessageId": "bc97c1ac-d514-5019-a4d0-9b35b1cb24ef",
-    "TopicArn": "arn:aws:sns:eu-west-1:945084044763:test-py-aws-topic",
-    "Subject": "Test Message",
-    "Message": "Hello World",
-    "Timestamp": "2022-03-02T12:27:11.628Z",
-    "SignatureVersion": "1",
-    "Signature": "JDdZ2eyRxXl7QA7JfboWU3KqSvuVwkJf2Eyl6eAc2bbLFvSGe0Iuc2Vfa5csvlZCfagrWQ+PrmNxoWQVbfK88LLgr69xqYw1eTLL+79BCrMAbZPq7Zq2xCPwG1z78O6fWlDxoJABbVTvokWy286B3iXblG3ZYdlEJelebxjRxccaLUqdQ7Zh9tK36fpbI4sXMJam71vKCplC/mQgxBq9TAF1vfv+A89oJ+glpBWRXMhrdQshB2T66sm/M03I9TVV/6j1/A3p4mAXa89QrczAB8zTVuSx7DwM7v+uZwXXqkKedxCflRApdV0kchioXCEXe7FzRPcQRAmFrWvlQTI2Ig==",
-    "SigningCertURL": "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-7ff5318490ec183fbaddaa2a969abfda.pem",
-    "UnsubscribeURL": "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:945084044763:test-py-aws-topic:583d9061-7e8e-4def-9a93-451f0cf30e19",
-}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+# pytest.ini
+[pytest]
+minversion = 6.0
+addopts = -ra -q
+asyncio_mode=strict
+testpaths =
+    tests

--- a/tests/test_aws_queue_listener.py
+++ b/tests/test_aws_queue_listener.py
@@ -6,15 +6,6 @@ from tibber_aws.aws_queue_listener import (MessageHandle, SqsMessage,
                                            json_message_processor)
 
 
-class TestQueue:
-    async def delete_message(self, msg_handle):
-        print("Deleted", msg_handle)
-        pass
-
-
-test_queue = TestQueue()
-
-
 @pytest.mark.asyncio
 async def test_json_message_processor():
     async def test_handler(message: SqsMessage):

--- a/tests/test_aws_queue_listener.py
+++ b/tests/test_aws_queue_listener.py
@@ -1,0 +1,40 @@
+import json
+
+import pytest
+
+from tibber_aws.aws_queue_listener import (MessageHandle, SqsMessage,
+                                           json_message_processor)
+
+
+class TestQueue:
+    async def delete_message(self, msg_handle):
+        print("Deleted", msg_handle)
+        pass
+
+
+test_queue = TestQueue()
+
+
+@pytest.mark.asyncio
+async def test_json_message_processor():
+    async def test_handler(message: SqsMessage):
+        assert message.subject == "Test Message"
+        assert json.loads(message.message)["Data"] == "Hello World"
+        assert message.message_id == "1f00b2a8-cfaa-58b6-852c-e83e24249122"
+
+    body = {
+        "Type": "Notification",
+        "MessageId": "1f00b2a8-cfaa-58b6-852c-e83e24249122",
+        "TopicArn": "arn:aws:sns:eu-west-1:945084044763:test-py-aws-topic",
+        "Subject": "Test Message",
+        "Message": '{\n  "Data": "Hello World"\n}',
+        "Timestamp": "2022-02-28T15:25:02.462Z",
+        "SignatureVersion": "1",
+        "Signature": "mdimGxOWejY+PLhumoZct7Tcsv13oFrutBwTm59BvbvbaDFgHfdHLkEKr9XlGPkKo85Ub/eo4ccIgf9PBoJf0I9EQlDaGw4niiKp722D6MzY4nRoutbyazNBgobyb0Cp5hsmTBSVmiGSeU5M2IS5Jo7AXhl8oA4DXLZii2vu/LLOS9rM9YrNrdf82an7FohhLzFRki46AwJwSOKpYQn5EktB9r7KhGEs49WKzpHQ6NGFzGJVosoJCjICknkiMLpQGXm7ssnI1l06quNN0R46tP/Snq3hhNzeYMVEC2huRQNVpdS4nDPp3tpYfTNjhzGOs+q5ZcUpWDtAoxBpaYG5gA==",
+        "SigningCertURL": "https://sns.eu-west-1.amazonaws.com/SimpleNotificationService-7ff5318490ec183fbaddaa2a969abfda.pem",
+        "UnsubscribeURL": "https://sns.eu-west-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-1:945084044763:test-py-aws-topic:583d9061-7e8e-4def-9a93-451f0cf30e19",
+    }
+    msg = {"Body": json.dumps(body)}
+    msg_handle = MessageHandle(msg)
+    handlers = {"Test Message": test_handler}
+    await json_message_processor(msg_handle, handlers)

--- a/tibber_aws/aws_queue_listener.py
+++ b/tibber_aws/aws_queue_listener.py
@@ -1,0 +1,172 @@
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+
+from aiobotocore.session import get_session
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class SqsMessage:
+    type: str
+    message_id: str
+    topic_arn: str
+    subject: str
+    message: str
+    timestamp: str
+    signature_version: str
+    signature: str
+    signing_cert_url: str
+    unsubscribe_url: str
+
+    @staticmethod
+    def from_json(msg):
+        return SqsMessage(
+            type=msg.get("Type"),
+            message_id=msg.get("MessageId"),
+            topic_arn=msg.get("TopicArn"),
+            subject=msg.get("Subject"),
+            message=msg.get("Message"),
+            timestamp=msg.get("Timestamp"),
+            signature_version=msg.get("SignatureVersion"),
+            signature=msg.get("Signature"),
+            signing_cert_url=msg.get("SigningCertURL"),
+            unsubscribe_url=msg.get("UnsubscribeURL"),
+        )
+
+
+class MessageHandle:
+    def __init__(self, msg):
+        self._msg = msg
+
+    @property
+    def body(self):
+        return self._msg["Body"]
+
+    @property
+    def receipt_handle(self):
+        return self._msg["ReceiptHandle"]
+
+
+async def json_message_processor(msg_handle, handlers: dict):
+    message = SqsMessage.from_json(json.loads(msg_handle.body))
+    await handlers[message.subject](message)
+
+
+class AwsQueueListener:
+    def __init__(
+        self,
+        sqs_client,
+        queue_url: str,
+        handlers: dict,
+        max_num_msgs=1,
+        wait_time_seconds=2,
+    ):
+        self._sqs_client = sqs_client
+        self._queue_url = queue_url
+        self._handlers = handlers
+        self._max_num_msgs = max_num_msgs
+        self._wait_time_seconds = wait_time_seconds
+
+    async def run(self):
+        async def process_message(msg_handle):
+            try:
+                await json_message_processor(msg_handle, self._handlers)
+                await self.delete_message(msg_handle)
+            except Exception as e:
+                _LOGGER.exception(e)
+
+        while True:
+            msg_handles = await self.receive_message()
+            if msg_handles:
+                running_tasks = []
+                for msg_handle in msg_handles:
+                    if msg_handle is None:
+                        continue
+                    running_tasks.append(
+                        asyncio.ensure_future(process_message(msg_handle))
+                    )
+
+                if running_tasks:
+                    tasks_completed, _ = await asyncio.wait(
+                        running_tasks, return_when=asyncio.FIRST_COMPLETED
+                    )
+                    for task in tasks_completed:
+                        running_tasks.remove(task)
+
+    async def receive_message(self) -> list:
+        """
+        Receive messages from the queue.
+        max_num_msgs: Maximum number of messages to receive.
+        wait_time_seconds: Wait time in seconds for receiving messages.
+        return: List of messages.
+        """
+        response = await self._sqs_client.receive_message(
+            QueueUrl=self._queue_url,
+            MaxNumberOfMessages=self._max_num_msgs,
+            WaitTimeSeconds=self._wait_time_seconds,
+        )
+        return [MessageHandle(msg) for msg in response.get("Messages", [])]
+
+    async def delete_message(self, msg_handle: MessageHandle) -> None:
+        await self._sqs_client.delete_message(
+            QueueUrl=self._queue_url, ReceiptHandle=msg_handle.receipt_handle
+        )
+
+
+async def create_queue_with_subscription(
+    queue_name, topic_name, region_name="eu-west-1"
+):
+    session = get_session()
+    async with session.create_client("sqs", region_name) as sqs:
+        async with session.create_client("sns", region_name) as sns:
+            response = await sqs.create_queue(QueueName=queue_name)
+            queue_url = response["QueueUrl"]
+            attr_response = await sqs.get_queue_attributes(
+                QueueUrl=queue_url, AttributeNames=["All"]
+            )
+
+            queue_attributes = attr_response.get("Attributes")
+            queue_arn = queue_attributes.get("QueueArn")
+
+            if "Policy" in queue_attributes:
+                policy = json.loads(queue_attributes["Policy"])
+            else:
+                policy = {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Sid": "Sid" + str(int(time.time())),
+                            "Effect": "Allow",
+                            "Principal": {"AWS": "*"},
+                            "Action": ["sqs:SendMessage", "sqs:ReceiveMessage"],
+                        }
+                    ],
+                }
+
+            statement = policy.get("Statement", [{}])[0]
+            statement["Resource"] = statement.get("Resource", queue_arn)
+            statement["Condition"] = statement.get("Condition", {})
+            statement["Condition"]["StringLike"] = statement["Condition"].get(
+                "StringLike", {}
+            )
+            source_arn = statement["Condition"]["StringLike"].get("aws:SourceArn", [])
+            if not isinstance(source_arn, list):
+                source_arn = [source_arn]
+
+            response = await sns.create_topic(Name=topic_name)
+            topic_arn = response["TopicArn"]
+
+            if topic_arn not in source_arn:
+                source_arn.append(topic_arn)
+                statement["Condition"]["StringLike"]["aws:SourceArn"] = source_arn
+                policy["Statement"] = statement
+                await sqs.set_queue_attributes(
+                    QueueUrl=queue_url, Attributes={"Policy": json.dumps(policy)}
+                )
+
+            await sns.subscribe(TopicArn=topic_arn, Protocol="sqs", Endpoint=queue_arn)
+
+    return queue_url

--- a/tibber_aws/aws_queue_listener.py
+++ b/tibber_aws/aws_queue_listener.py
@@ -96,13 +96,7 @@ class AwsQueueListener:
                     for task in tasks_completed:
                         running_tasks.remove(task)
 
-    async def receive_message(self) -> list:
-        """
-        Receive messages from the queue.
-        max_num_msgs: Maximum number of messages to receive.
-        wait_time_seconds: Wait time in seconds for receiving messages.
-        return: List of messages.
-        """
+    async def receive_message(self) -> list[MessageHandle]:
         response = await self._sqs_client.receive_message(
             QueueUrl=self._queue_url,
             MaxNumberOfMessages=self._max_num_msgs,

--- a/tibber_aws/aws_queue_listener.py
+++ b/tibber_aws/aws_queue_listener.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import time
 from dataclasses import dataclass
 
 from aiobotocore.session import get_session


### PR DESCRIPTION
Adds new implementation for consuming messages (`AwsQueueListener`) from SQS queues.

Creating queues and topics and create subscriptions is now done outside the queue consumption. (`subscribe_topic`)
 